### PR TITLE
Update CitizenCardNumberGenerator.cs

### DIFF
--- a/src/DocumentNumber.Portugal.CitizenCard.Generator/CitizenCardNumberGenerator.cs
+++ b/src/DocumentNumber.Portugal.CitizenCard.Generator/CitizenCardNumberGenerator.cs
@@ -24,7 +24,7 @@
         sum += translatedValue;
       }
       int checkdigit;
-      checkdigit = 10 - (sum % 10);
+      checkdigit = (10 - (sum % 10)) % 10;
 
 
       return checkdigit;


### PR DESCRIPTION
Fixed check digit calculation to correctly handle the case when the modulo operation results in 10.
Fixes issue #18 